### PR TITLE
Fixed exception that happening after image download

### DIFF
--- a/uikit/src/main/java/com/sendbird/uikit/fragments/PhotoViewFragment.java
+++ b/uikit/src/main/java/com/sendbird/uikit/fragments/PhotoViewFragment.java
@@ -283,7 +283,7 @@ public class PhotoViewFragment extends BaseFragment implements PermissionFragmen
             @Override
             public Boolean call() throws Exception {
                 FileDownloader.getInstance().saveFile(getContext(), url, mimeType, fileName);
-                Logger.dev("++ file name : %s, size : %s", fileName);
+                Logger.dev("++ file name : %s", fileName);
                 return true;
             }
 


### PR DESCRIPTION
Hi there!
I have found that after downloading image from photo preview screen, I'm getting "Could't download file." I've debug the issue and found that crash is happening after creating string by `String.format()` function, so I prepared small fix for that.